### PR TITLE
添加了一个变量控制是否启用计数功能，停用后不再保存网站次数到文件中。但是因为不会开发chrome扩展，所以只能把变量写死

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -1,3 +1,4 @@
+let enableCount = false;
 let OPERATIONS = {
   menu: {
     addUrlBlacklist: "URL加入黑名单（不再访问）",
@@ -335,6 +336,7 @@ let TABS = {
   },
   setTabBadge: function (tab) {
     try {
+      if (!enableCount) return;
       let stableUrl = URL_UTILS.getStableUrl(tab.url);
       COUNTING.getBrowsedTimes(stableUrl, function (browseTimes) {
         if (URL_UTILS.isWhitelist(stableUrl) || URL_UTILS.isBlacklist(stableUrl) || !browseTimes) {
@@ -381,6 +383,7 @@ let TABS = {
 let COUNTING = {
   increaseAndShowBrowseTimes: function (tab) { // 含异步接口，妥协单一职责
     consoleDebug('COUNTING.increaseAndShowBrowseTimes()');
+    if (!enableCount) return;
     let stableUrl = URL_UTILS.getStableUrl(tab.url);
     COUNTING.getBrowsedTimes(stableUrl, function (times) {
       times = (times || 0) + 1;
@@ -477,6 +480,7 @@ let URL_UTILS = {
   },
 
   isWhitelist: function (url) {
+    if (!enableCount) return true;
     let isDefaultWhitelist = /^chrome/.test(url)
       || /^https?:\/\/www\.baidu\.com/.test(url)
       || /^https?:\/\/www\.google\.com/.test(url);


### PR DESCRIPTION
在设置里关闭计数后，只是网页不显示，但是扩展图标上仍然在计数，网站和次数也会保存到文件中。
希望能加个设置，选择是否启用计数。
我改了一点点，停用后，isWhitelist会直接返回true，网站和次数不会保存。